### PR TITLE
README.md: Add dwarves to list of build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Instructions for building an x86_64 WSL2 kernel with an Ubuntu distribution are
 as follows:
 
 1. Install the build dependencies:  
-   `$ sudo apt install build-essential flex bison libssl-dev libelf-dev`
+   `$ sudo apt install build-essential flex bison dwarves libssl-dev libelf-dev`
 2. Build the kernel using the WSL2 kernel configuration:  
    `$ make KCONFIG_CONFIG=Microsoft/config-wsl`
 


### PR DESCRIPTION
dwarves package provides pahole without which build fails with

    BTF: .tmp_vmlinux.btf: pahole (pahole) is not available
    Failed to generate BTF for vmlinux
    Try to disable CONFIG_DEBUG_INFO_BTF